### PR TITLE
Blacklist on refresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
 cache: bundler
 
 before_install:
-  - gem install bundler:2.0.1
+  - gem install bundler:1.17.3
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-### Changelog
+## Changelog
+
+### 0.2.0 - 2019-04-27
+
+* Features
+    * Added configurable option to blacklist JWT access token on refreshing as requested in this 
+    [issue comment](https://github.com/Gokul595/api_guard/issues/8#issuecomment-477436164).
 
 ### 0.1.3 - 2019-03-26
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,13 +66,13 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     rack (2.0.4)
@@ -124,7 +124,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -153,4 +153,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3, >= 1.3.13)
 
 BUNDLED WITH
-   2.0.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    api_guard (0.1.3)
+    api_guard (0.2.0)
       jwt (~> 2.1, >= 2.1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -362,6 +362,10 @@ ApiGuard.setup do |config|
   # Invalidate old tokens on changing the password
   # Default: false
   config.invalidate_old_tokens_on_password_change = false
+
+  # Blacklist JWT access token after refreshing
+  # Default: false
+  config.blacklist_token_after_refreshing = false
 end
 ```
 
@@ -472,6 +476,15 @@ api_guard_associations refresh_token: 'refresh_tokens', blacklisted_token: 'blac
 And, as this creates rows in `blacklisted_tokens` table you need to have a mechanism to delete the expired blacklisted 
 tokens to prevent this table from growing. One option is to have a CRON job to run a task daily that deletes the 
 blacklisted tokens that are expired i.e. `expire_at < DateTime.now`.
+
+**Blacklisting after refreshing token**
+
+By default, the JWT access token will not be blacklisted on refreshing the JWT access token. To enable this, you can 
+configure it in API Guard initializer as below,
+
+```ruby
+config.blacklist_token_after_refreshing = true
+```
 
 ## Overriding defaults
 

--- a/app/controllers/api_guard/tokens_controller.rb
+++ b/app/controllers/api_guard/tokens_controller.rb
@@ -6,8 +6,11 @@ module ApiGuard
     before_action :find_refresh_token, only: [:create]
 
     def create
-      @refresh_token.destroy
       create_token_and_set_header(current_resource, resource_name)
+
+      @refresh_token.destroy
+      blacklist_token if ApiGuard.blacklist_token_after_refreshing
+
       render_success(message: 'Token refreshed successfully')
     end
 

--- a/lib/api_guard.rb
+++ b/lib/api_guard.rb
@@ -16,6 +16,9 @@ module ApiGuard
   mattr_accessor :invalidate_old_tokens_on_password_change
   self.invalidate_old_tokens_on_password_change = false
 
+  mattr_accessor :blacklist_token_after_refreshing
+  self.blacklist_token_after_refreshing = false
+
   mattr_accessor :api_guard_associations
   self.api_guard_associations = {}
 

--- a/lib/api_guard/version.rb
+++ b/lib/api_guard/version.rb
@@ -1,3 +1,3 @@
 module ApiGuard
-  VERSION = '0.1.3'
+  VERSION = '0.2.0'
 end

--- a/lib/generators/api_guard/initializer/templates/initializer.rb
+++ b/lib/generators/api_guard/initializer/templates/initializer.rb
@@ -10,4 +10,8 @@ ApiGuard.setup do |config|
   # Invalidate old tokens on changing the password
   # Default: false
   config.invalidate_old_tokens_on_password_change = false
+
+  # Blacklist JWT access token after refreshing
+  # Default: false
+  config.blacklist_token_after_refreshing = false
 end

--- a/spec/dummy/spec/requests/users/tokens_requests_spec.rb
+++ b/spec/dummy/spec/requests/users/tokens_requests_spec.rb
@@ -66,6 +66,20 @@ describe 'Refresh token - User', type: :request do
         expect(response.headers['Refresh-Token']).to be_present
       end
 
+      it 'should delete refresh token received in request' do
+        user = create(:user)
+        expired_access_token, refresh_token = jwt_and_refresh_token(user, 'user', true)
+
+        post '/users/tokens', headers: {'Authorization': "Bearer #{expired_access_token}", 'Refresh-Token': refresh_token}
+
+        expect(response).to have_http_status(200)
+        expect(response.headers['Access-Token']).to be_present
+        expect(response.headers['Expire-At']).to be_present
+        expect(response.headers['Refresh-Token']).to be_present
+
+        expect(user.refresh_tokens.find_by(token: refresh_token)).to be_nil
+      end
+
       it 'should blacklist JWT access token after refreshing' do
         user = create(:user)
         access_token, refresh_token = jwt_and_refresh_token(user, 'user')

--- a/spec/dummy/spec/requests/users/tokens_requests_spec.rb
+++ b/spec/dummy/spec/requests/users/tokens_requests_spec.rb
@@ -65,6 +65,38 @@ describe 'Refresh token - User', type: :request do
         expect(response.headers['Expire-At']).to be_present
         expect(response.headers['Refresh-Token']).to be_present
       end
+
+      it 'should blacklist JWT access token after refreshing' do
+        user = create(:user)
+        access_token, refresh_token = jwt_and_refresh_token(user, 'user')
+
+        ApiGuard.blacklist_token_after_refreshing = true
+
+        expect do
+          post '/users/tokens', headers: {'Authorization': "Bearer #{access_token}", 'Refresh-Token': refresh_token}
+        end.to change(user.blacklisted_tokens, :count).by(1)
+
+        ApiGuard.blacklist_token_after_refreshing = false
+
+        expect(response).to have_http_status(200)
+        expect(response.headers['Access-Token']).to be_present
+        expect(response.headers['Expire-At']).to be_present
+        expect(response.headers['Refresh-Token']).to be_present
+      end
+
+      it 'should not blacklist JWT access token after refreshing' do
+        user = create(:user)
+        access_token, refresh_token = jwt_and_refresh_token(user, 'user')
+
+        expect do
+          post '/users/tokens', headers: {'Authorization': "Bearer #{access_token}", 'Refresh-Token': refresh_token}
+        end.to change(user.blacklisted_tokens, :count).by(0)
+
+        expect(response).to have_http_status(200)
+        expect(response.headers['Access-Token']).to be_present
+        expect(response.headers['Expire-At']).to be_present
+        expect(response.headers['Refresh-Token']).to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
Added option to blacklist JWT access token on refreshing as requested in [this issue comment](https://github.com/Gokul595/api_guard/issues/8#issuecomment-477436164).