### PR TITLE
Add spec for registration error due to duplicate email

### DIFF
--- a/spec/dummy/spec/requests/users/registration_requests_spec.rb
+++ b/spec/dummy/spec/requests/users/registration_requests_spec.rb
@@ -31,6 +31,16 @@ describe 'Registration - User', type: :request do
         expect(response.headers['Expire-At']).to be_present
         expect(response.headers['Refresh-Token']).to be_present
       end
+
+      it 'should return 422 - email has already been taken' do
+        user = create(:user)
+        expect do
+          post '/users/sign_up', params: attributes_for(:user)
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(422)
+        expect(response_errors).to eq('Email has already been taken')
+      end
     end
   end
 


### PR DESCRIPTION
Just wanted to add a (passing) spec for the situation where an error is raised on registration. Thanks for the great gem!