### PR TITLE
Add custom data in JWT token & customize resource finding logic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'lib/generators/api_guard/controllers/templates/*'
+    - 'spec/dummy/db/schema.rb'
 
 Rails:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ To add custom data, you need to create an instance method `jwt_token_payload` in
 should return a Hash,
 
 ```ruby
-class User
+class User < ApplicationRecord
   def jwt_token_payload
     { custom_key: 'value' }
   end
@@ -598,7 +598,7 @@ By default, API Guard will try to find the resource by it's `id`. If you wish to
 do it by creating a method `find_resource_from_token` in the specific controller or in `ApplicationController` as you 
 need.
 
-**Adding custom logic using the user found from the token:**
+**Adding custom logic in addition to the default logic:**
 ```ruby
 def find_resource_from_token(resource_class)
   user = super # This will call the actual method defined in API Guard

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ for cryptographic signing.
 * [Overriding defaults](#overriding-defaults)
     * [Controllers](#controllers)
     * [Routes](#routes)
+    * [Adding custom data in JWT token payload](#adding-custom-data-in-jwt-token-payload)
+    * [Override finding resource](#override-finding-resource)
     * [Customizing / translating response messages using I18n](#customizing--translating-response-messages-using-i18n)
 * [Testing](#testing)
 * [Wiki](https://github.com/Gokul595/api_guard/wiki)
@@ -565,6 +567,58 @@ end
 
 Above configuration will replace default registration routes `users/sign_up` & `users/delete` with `account/create` & 
 `account/delete`
+
+### Adding custom data in JWT token payload
+
+You can add custom data in the JWT token payload in the format of Hash and use the data after decoding the token on 
+every request.
+
+To add custom data, you need to create an instance method `jwt_token_payload` in the resource model as below which 
+should return a Hash,
+
+```ruby
+class User
+  def jwt_token_payload
+    { custom_key: 'value' }
+  end
+end
+```
+
+API Guard will add the hash returned by this method to the JWT token payload in addition to the default payload values. 
+This data (including default payload values) will be available in the instance variable `@decoded_token` on each request 
+if the token has been successfully decoded. You can access the values as below,
+
+```ruby
+@decoded_token[:custom_key]
+```
+
+### Override finding resource
+
+By default, API Guard will try to find the resource by it's `id`. If you wish to override this default behavior, you can
+do it by creating a method `find_resource_from_token` in the specific controller or in `ApplicationController` as you 
+need.
+
+**Adding custom logic using the user found from the token:**
+```ruby
+def find_resource_from_token(resource_class)
+  user = super # This will call the actual method defined in API Guard
+  user if user&.active?
+end
+```
+
+**Using custom query to find the user from the token:**
+```ruby
+def find_resource_from_token(resource_class)
+  resource_id = @decoded_token[:"#{@resource_name}_id"]
+  resource_class.find_by(id: resource_id, status: 'active') if resource_id
+end
+```
+
+This method has an argument `resource_class` which is the class (model) of the current resource (`User`).
+This method should return a resource object to successfully authenticate the request or `nil` to respond with 401.
+
+You can also use the [custom data](#adding-custom-data-in-jwt-token-payload) added in the JWT token payload using 
+`@decoded_token` instance variable and customize the logic as you need.
 
 ### Customizing / translating response messages using I18n
 

--- a/lib/api_guard/jwt_auth/blacklist_token.rb
+++ b/lib/api_guard/jwt_auth/blacklist_token.rb
@@ -18,10 +18,10 @@ module ApiGuard
       end
 
       # Returns whether the JWT token is blacklisted or not
-      def blacklisted?
-        return false unless token_blacklisting_enabled?(current_resource)
+      def blacklisted?(resource)
+        return false unless token_blacklisting_enabled?(resource)
 
-        blacklisted_tokens_for(current_resource).exists?(token: @token)
+        blacklisted_tokens_for(resource).exists?(token: @token)
       end
 
       # Blacklist the current JWT token from future access

--- a/lib/api_guard/jwt_auth/json_web_token.rb
+++ b/lib/api_guard/jwt_auth/json_web_token.rb
@@ -35,13 +35,16 @@ module ApiGuard
       #
       # This creates expired JWT token if the argument 'expired_token' is true which can be used for testing.
       def jwt_and_refresh_token(resource, resource_name, expired_token = false)
-        access_token = encode(
+        payload = {
           "#{resource_name}_id": resource.id,
           exp: expired_token ? token_issued_at : token_expire_at,
           iat: token_issued_at
-        )
+        }
 
-        [access_token, new_refresh_token(resource)]
+        # Add custom data in the JWT token payload
+        payload.merge!(resource.jwt_token_payload) if resource.respond_to?(:jwt_token_payload)
+
+        [encode(payload), new_refresh_token(resource)]
       end
 
       # Create tokens and set response headers

--- a/spec/dummy/app/controllers/admins/posts_controller.rb
+++ b/spec/dummy/app/controllers/admins/posts_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admins
+  class PostsController < ApplicationController
+    before_action :authenticate_and_set_admin
+
+    def update
+      post = Post.find(params[:id])
+      post.update(content: params[:post][:content])
+
+      render json: post.as_json
+    end
+
+    private
+
+    def find_resource_from_token(resource_class)
+      admin = super
+      admin if admin.edit_all_posts? || @decoded_token[:force_allow_editing_post]
+    end
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     authentication: 'admins/auth'
   }
 
+  namespace :admins do
+    resources :posts, only: [:update]
+  end
+
   api_guard_routes for: 'users', path: 'customers', as: 'customer', except: %i[registration], controller: {
     authentication: 'customers/authentication',
     tokens: 'customers/tokens',

--- a/spec/dummy/db/migrate/20200426061831_add_edit_all_posts_to_admin.rb
+++ b/spec/dummy/db/migrate/20200426061831_add_edit_all_posts_to_admin.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEditAllPostsToAdmin < ActiveRecord::Migration[5.1]
+  def change
+    add_column :admins, :edit_all_posts, :boolean, default: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,50 +10,53 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_217_061_814) do
-  create_table 'admins', force: :cascade do |t|
-    t.string 'email'
-    t.string 'password_digest'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.datetime 'token_issued_at'
+ActiveRecord::Schema.define(version: 20200426061831) do
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "token_issued_at"
+    t.boolean "edit_all_posts", default: false
   end
 
-  create_table 'blacklisted_tokens', force: :cascade do |t|
-    t.string 'token'
-    t.datetime 'expire_at'
-    t.integer 'user_id'
-    t.integer 'admin_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['admin_id'], name: 'index_blacklisted_tokens_on_admin_id'
-    t.index ['user_id'], name: 'index_blacklisted_tokens_on_user_id'
+  create_table "blacklisted_tokens", force: :cascade do |t|
+    t.string "token"
+    t.datetime "expire_at"
+    t.integer "user_id"
+    t.integer "admin_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["admin_id"], name: "index_blacklisted_tokens_on_admin_id"
+    t.index ["user_id"], name: "index_blacklisted_tokens_on_user_id"
   end
 
-  create_table 'posts', force: :cascade do |t|
-    t.integer 'user_id'
-    t.text 'content'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", force: :cascade do |t|
+    t.integer "user_id"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'refresh_tokens', force: :cascade do |t|
-    t.string 'token'
-    t.integer 'user_id'
-    t.integer 'admin_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['admin_id'], name: 'index_refresh_tokens_on_admin_id'
-    t.index ['token'], name: 'index_refresh_tokens_on_token', unique: true
-    t.index ['user_id'], name: 'index_refresh_tokens_on_user_id'
+  create_table "refresh_tokens", force: :cascade do |t|
+    t.string "token"
+    t.integer "user_id"
+    t.integer "admin_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["admin_id"], name: "index_refresh_tokens_on_admin_id"
+    t.index ["token"], name: "index_refresh_tokens_on_token", unique: true
+    t.index ["user_id"], name: "index_refresh_tokens_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email'
-    t.string 'password_digest'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.datetime 'token_issued_at'
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "token_issued_at"
   end
+
 end

--- a/spec/dummy/spec/requests/custom_token_payload_spec.rb
+++ b/spec/dummy/spec/requests/custom_token_payload_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'dummy/spec/rails_helper'
+
+describe 'Admins::Posts with custom token payload', type: :request do
+  before :each, create_post: true do
+    user = create(:user)
+    @post = create(:post, user_id: user.id)
+  end
+
+  describe 'GET #index' do
+    context 'with invalid params' do
+      it 'should return 401 - missing access token' do
+        patch '/admins/posts/1'
+
+        expect(response).to have_http_status(401)
+        expect(response_errors).to eq('Access token is missing in the request')
+      end
+
+      it 'should return 401 - invalid access token' do
+        patch '/admins/posts/1', headers: { 'Authorization': 'Bearer invalid_token' }
+
+        expect(response).to have_http_status(401)
+        expect(response_errors).to eq('Invalid access token')
+      end
+
+      it 'should return 401 - expired access token' do
+        admin = create(:admin)
+        expired_access_token = jwt_and_refresh_token(admin, 'admin', true)[0]
+
+        patch '/admins/posts/1', headers: { 'Authorization': "Bearer #{expired_access_token}" }
+
+        expect(response).to have_http_status(401)
+        expect(response_errors).to eq('Access token expired')
+      end
+
+      it 'should return 401 - blacklisted access token' do
+        admin = create(:admin)
+        access_token = jwt_and_refresh_token(admin, 'admin')[0]
+
+        admin.blacklisted_tokens.create(token: access_token, expire_at: Time.now.utc)
+
+        patch '/admins/posts/1', headers: { 'Authorization': "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(401)
+        expect(response_errors).to eq('Invalid access token')
+      end
+
+      it 'should return 401 - old access token' do
+        admin = create(:admin)
+        access_token = jwt_and_refresh_token(admin, 'admin')[0]
+
+        admin.update(token_issued_at: Time.now.utc + 1.second)
+
+        patch '/admins/posts/1', headers: { 'Authorization': "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(401)
+        expect(response_errors).to eq('Invalid access token')
+      end
+
+      it 'should return 401 when an admin try to edit post without edit_all_posts rights', create_post: true do
+        admin = create(:admin)
+
+        access_token = jwt_and_refresh_token(admin, 'admin')[0]
+
+        patch "/admins/posts/#{@post.id}",
+              params: { post: { content: 'Edited.' } },
+              headers: { 'Authorization': "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(401)
+        expect(@post.reload.content).not_to eq('Edited.')
+      end
+    end
+
+    context 'with valid params' do
+      it 'should allow editing post when the admin has edit_all_posts rights', create_post: true do
+        admin = create(:admin, edit_all_posts: true)
+
+        access_token = jwt_and_refresh_token(admin, 'admin')[0]
+
+        patch "/admins/posts/#{@post.id}",
+              params: { post: { content: 'Edited.' } },
+              headers: { 'Authorization': "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(200)
+        expect(parsed_response['content']).to eq('Edited.')
+      end
+
+      it 'should allow editing post when token has force_allow_editing_post value in the payload', create_post: true do
+        admin = create(:admin)
+
+        def admin.jwt_token_payload
+          { force_allow_editing_post: true }
+        end
+
+        access_token = jwt_and_refresh_token(admin, 'admin')[0]
+
+        patch "/admins/posts/#{@post.id}",
+              params: { post: { content: 'Edited.' } },
+              headers: { 'Authorization': "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(200)
+        expect(parsed_response['content']).to eq('Edited.')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds two new functionalities,

1. Option to add custom data in JWT token payload and allow using those value in each request.
2. Customize resource finding logic instead of using the default logic (finding by `id`) provided by API Guard.