### PR TITLE
Fix Issue #30 - Prevent sharing authenticated resource across the requests

### DIFF
--- a/lib/api_guard/jwt_auth/authentication.rb
+++ b/lib/api_guard/jwt_auth/authentication.rb
@@ -58,7 +58,7 @@ module ApiGuard
       # Defines "current_{{resource_name}}" method and "@current_{{resource_name}}" instance variable
       # that returns "resource" value
       def define_current_resource_accessors(resource)
-        self.class.send(:define_method, "current_#{@resource_name}") do
+        define_singleton_method("current_#{@resource_name}") do
           instance_variable_get("@current_#{@resource_name}") ||
             instance_variable_set("@current_#{@resource_name}", resource)
         end


### PR DESCRIPTION
This will prevent the authenticated resource from being shared across the requests.

Fixes: #30 