### PR TITLE
Authenticate and set multiple resources

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    api_guard (0.5.1)
+    api_guard (0.5.2)
       jwt (~> 2.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ To authenticate the API request just add this before_action in the controller:
 before_action :authenticate_and_set_user
 ```
 
+>**Note:** It is possible to authenticate with more than one resource, e.g. `authenticate_and_set_user_or_admin` will permit tokens issued for users or admins.
+
 Send the access token got in sign in API in the Authorization header in the API request as below. 
 Also, make sure you add "Bearer" before the access token in the header value.
 

--- a/lib/api_guard/version.rb
+++ b/lib/api_guard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ApiGuard
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/dummy/app/controllers/posts_controller.rb
+++ b/spec/dummy/app/controllers/posts_controller.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class PostsController < ApplicationController
-  before_action :authenticate_and_set_user
+  before_action :authenticate_and_set_user_or_admin
 
   def index
-    posts = current_user.posts
+    posts = current_user.posts if @current_user
+    posts = Post.all if @current_admin
     render json: posts.as_json
   end
 end

--- a/spec/dummy/spec/requests/posts_requests_spec.rb
+++ b/spec/dummy/spec/requests/posts_requests_spec.rb
@@ -29,6 +29,16 @@ describe 'Posts', type: :request do
         expect(response_errors).to eq('Access token expired')
       end
 
+      it 'should return 401 - expired access token - admin' do
+        admin = create(:admin)
+        expired_access_token = jwt_and_refresh_token(admin, 'admin', true)[0]
+
+        get '/posts', headers: { 'Authorization': "Bearer #{expired_access_token}" }
+
+        expect(response).to have_http_status(401)
+        expect(response_errors).to eq('Access token expired')
+      end
+
       it 'should return 401 - blacklisted access token' do
         user = create(:user)
         access_token = jwt_and_refresh_token(user, 'user')[0]
@@ -41,11 +51,35 @@ describe 'Posts', type: :request do
         expect(response_errors).to eq('Invalid access token')
       end
 
+      it 'should return 401 - blacklisted access token - admin' do
+        admin = create(:admin)
+        access_token = jwt_and_refresh_token(admin, 'admin')[0]
+
+        admin.blacklisted_tokens.create(token: access_token, expire_at: Time.now.utc)
+
+        get '/posts', headers: { 'Authorization': "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(401)
+        expect(response_errors).to eq('Invalid access token')
+      end
+
       it 'should return 401 - old access token' do
         user = create(:user)
         access_token = jwt_and_refresh_token(user, 'user')[0]
 
         user.update(token_issued_at: Time.now.utc + 1.second)
+
+        get '/posts', headers: { 'Authorization': "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(401)
+        expect(response_errors).to eq('Invalid access token')
+      end
+
+      it 'should return 401 - old access token - admin' do
+        admin = create(:admin)
+        access_token = jwt_and_refresh_token(admin, 'admin')[0]
+
+        admin.update(token_issued_at: Time.now.utc + 1.second)
 
         get '/posts', headers: { 'Authorization': "Bearer #{access_token}" }
 
@@ -68,6 +102,23 @@ describe 'Posts', type: :request do
 
         expect(response).to have_http_status(200)
         expect(parsed_response.map { |p| p['id'] }).to match_array(user_posts.map(&:id))
+      end
+
+      it 'should return all user posts' do
+        admin = create(:admin)
+        user = create(:user)
+        user1 = create(:user_1)
+
+        create_list(:post, 2, user_id: user.id)
+        create_list(:post, 2, user_id: user1.id)
+
+        access_token = jwt_and_refresh_token(admin, 'admin')[0]
+
+        get '/posts', headers: { 'Authorization': "Bearer #{access_token}" }
+
+        posts = Post.all
+        expect(response).to have_http_status(200)
+        expect(parsed_response.map { |p| p['id'] }).to match_array(posts.map(&:id))
       end
     end
   end


### PR DESCRIPTION
* Add support for `or` syntax in authentication method like:
```
before_action :authenticate_and_set_user_or_admin
```

* It is possible to use this syntax too:
```
before_action do
    authenticate_and_set_resources ["user", "admin"]
end
```

* Based on PR #26.