### PR TITLE
Fix for Rails 6.1 undefined method 'day' for 1:Integer

### DIFF
--- a/lib/api_guard.rb
+++ b/lib/api_guard.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/integer/time"
 require 'api_guard/engine'
 require 'api_guard/route_mapper'
 require 'api_guard/modules'


### PR DESCRIPTION
Closes #51 in relation with https://github.com/rails/rails/issues/37391